### PR TITLE
Add chatbot widget using ElevenLabs

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,15 +15,8 @@ AgentVoice is a minimal demonstration of integrating ElevenLabs text-to-speech w
 
 ## Running the Web Page
 
-The repository contains a basic HTML file that calls the ElevenLabs API. After starting your local server, navigate to the page in your browser and interact with it.
+The repository contains a basic HTML file that calls the ElevenLabs API. After starting your local server, navigate to the page in your browser and interact with it. A floating button in the bottom-right corner opens a simple chatbot widget where you can send text or start a voice call.
 
 ## Configuring ElevenLabs Credentials
 
-Create a file named `.env` in the project root (or set environment variables in your hosting environment) with the following contents:
-
-```
-ELEVEN_API_KEY=your-api-key-here
-ELEVEN_VOICE_ID=your-voice-id
-```
-
-Replace the placeholder values with your ElevenLabs API key and the voice ID you want to use. The web page reads these values to authenticate requests to the ElevenLabs service.
+Open `script.js` and replace the `ELEVEN_API_KEY` and `ELEVEN_VOICE_ID` placeholders with your own ElevenLabs credentials. These values are required for the page to authenticate requests to the ElevenLabs service.

--- a/index.html
+++ b/index.html
@@ -13,6 +13,13 @@
         <button id="mode-toggle" aria-label="Toggle Dark Mode">Toggle Dark Mode</button>
     </header>
 
+    <div id="chatbot-widget" class="chatbot-widget">
+        <textarea id="chat-input" placeholder="Type a message..."></textarea>
+        <button id="send-button">Send</button>
+        <button id="call-button">Voice Call</button>
+    </div>
+    <button id="chatbot-button" class="chatbot-button" aria-label="Open Chatbot">Chat</button>
+
     <script src="script.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -1,3 +1,67 @@
 document.getElementById('mode-toggle').addEventListener('click', () => {
     document.body.classList.toggle('dark-mode');
 });
+
+// ElevenLabs credentials - replace with your values
+const ELEVEN_API_KEY = '';
+const ELEVEN_VOICE_ID = '';
+
+const chatButton = document.getElementById('chatbot-button');
+const chatWidget = document.getElementById('chatbot-widget');
+const sendButton = document.getElementById('send-button');
+const callButton = document.getElementById('call-button');
+const chatInput = document.getElementById('chat-input');
+
+chatButton.addEventListener('click', () => {
+    chatWidget.classList.toggle('open');
+});
+
+sendButton.addEventListener('click', () => {
+    const text = chatInput.value.trim();
+    if (text) {
+        speakText(text);
+    }
+});
+
+callButton.addEventListener('click', () => {
+    startVoiceCall();
+});
+
+async function speakText(text) {
+    if (!ELEVEN_API_KEY || !ELEVEN_VOICE_ID) {
+        console.error('ElevenLabs credentials are missing');
+        return;
+    }
+    const response = await fetch(`https://api.elevenlabs.io/v1/text-to-speech/${ELEVEN_VOICE_ID}/stream`, {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+            'xi-api-key': ELEVEN_API_KEY
+        },
+        body: JSON.stringify({ text })
+    });
+    const arrayBuffer = await response.arrayBuffer();
+    const blob = new Blob([arrayBuffer], { type: 'audio/mpeg' });
+    const url = URL.createObjectURL(blob);
+    const audio = new Audio(url);
+    audio.play();
+}
+
+function startVoiceCall() {
+    const SpeechRecognition = window.SpeechRecognition || window.webkitSpeechRecognition;
+    if (!SpeechRecognition) {
+        alert('Speech recognition not supported in this browser');
+        return;
+    }
+    const recognition = new SpeechRecognition();
+    recognition.lang = 'en-US';
+    recognition.interimResults = false;
+    recognition.onresult = (event) => {
+        const transcript = event.results[0][0].transcript;
+        speakText(transcript);
+    };
+    recognition.onerror = (event) => {
+        console.error('Speech recognition error', event);
+    };
+    recognition.start();
+}

--- a/style.css
+++ b/style.css
@@ -33,3 +33,50 @@ body.dark-mode {
     padding: 0.5rem 1rem;
     cursor: pointer;
 }
+
+/* Chatbot styles */
+.chatbot-button {
+    position: fixed;
+    bottom: 20px;
+    right: 20px;
+    width: 60px;
+    height: 60px;
+    border-radius: 50%;
+    background-color: #007bff;
+    color: #ffffff;
+    border: none;
+    font-size: 1rem;
+    cursor: pointer;
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.3);
+    z-index: 1000;
+}
+
+.chatbot-widget {
+    position: fixed;
+    bottom: 90px;
+    right: 20px;
+    width: 300px;
+    background-color: #ffffff;
+    border: 1px solid #ccc;
+    border-radius: 8px;
+    padding: 10px;
+    display: none;
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.3);
+    z-index: 1000;
+}
+
+.chatbot-widget.open {
+    display: block;
+}
+
+.chatbot-widget textarea {
+    width: 100%;
+    height: 60px;
+    resize: none;
+}
+
+.chatbot-widget button {
+    margin-top: 5px;
+    width: 100%;
+    padding: 0.5rem;
+}


### PR DESCRIPTION
## Summary
- add chatbot widget markup
- style chatbot button and widget
- integrate ElevenLabs API via script
- describe new credentials setup

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68435a59916c832ab1c66902d37813d7