### PR TITLE
Add install step in compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,5 +4,7 @@ services:
     build: .
     volumes:
       - ./frontend:/usr/src/app
+      - /usr/src/app/node_modules
+    command: sh -c "npm install && npm start"
     ports:
       - "4200:4200"


### PR DESCRIPTION
## Summary
- ensure `node_modules` isn't bind-mounted from host
- install dependencies on container startup

## Testing
- `docker-compose up --build -d` *(fails: `docker-compose: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68436cde33a8832aa5fccc5c6f6b2b43